### PR TITLE
update SQLAlchemy-Utils new version 0.37.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ PyYAML==5.4.1
 requests==2.25.1
 six==1.15.0
 SQLAlchemy==1.4.6
-SQLAlchemy-Utils==0.36.8
+SQLAlchemy-Utils==0.37.0


### PR DESCRIPTION
SQLAlchemy version 1.4.6 is not compatible with  SQLAlchemy-Utils 0.36.8 ; 
cannot import funtions drop_database & database_exists from sqlalchemy_utils : 
ImportError: cannot import name '_ColumnEntity' from 'sqlalchemy.orm.query'