### PR TITLE
unable to  parse new time format by perl module in datacheck

### DIFF
--- a/src/ensembl/production/core/models/hive.py
+++ b/src/ensembl/production/core/models/hive.py
@@ -252,7 +252,7 @@ class HiveInstance:
         The input_data dict is converted to a Perl string before storing
         """
 
-        input_data['timestamp'] = time.time()
+        input_data['timestamp'] = time.ctime() 
         analysis = self.get_analysis_by_name(analysis_name)
         if analysis is None:
             raise ValueError("Analysis %s not found" % analysis_name)


### PR DESCRIPTION
time.time() method returns a time format whcih was unable to pare by perl module in datacheck step : 

Error parsing time at /nfs/software/ensembl/RHEL7-JUL2017-core2/plenv/versions/5.14.4/lib/perl5/5.14.4/x86_64-linux-thread-multi-ld/Time/Piece.pm line 469.

required time format is : `Wed Sep 16 14:52:15 2020` ; 

time.ctime() method will return the required format . 
