### PR TITLE
get_database_set & get_table_set filters "match" instead of "search"

### DIFF
--- a/src/ensembl/production/core/db_introspects.py
+++ b/src/ensembl/production/core/db_introspects.py
@@ -35,16 +35,19 @@ def get_table_names(engine, database):
 
 
 def _filter_names(names_list, filters):
-    filtered_names = set()
+    filter_names = set()
+    filter_regexes = []
     if filters:
         try:
-            for filter_re in filters:
-                re.compile(filter_re)
+            for filter_name in filters:
+                filter_regex = '^{}$'.format(filter_name)
+                re.compile(filter_regex)
+                filter_regexes.append(filter_regex)
         except re.error as e:
-            raise ValueError('Invalid name_filter: {}'.format(filter_re)) from e
-        filter_names_re = re.compile('$|^'.join(filters))
-        filtered_names = set(filter(filter_names_re.search, names_list))
-    return filtered_names
+            raise ValueError('Invalid name_filter: {}'.format(filter_name)) from e
+        filter_names_re = re.compile('|'.join(filter_regexes))
+        filter_names = set(filter(filter_names_re.match, names_list))
+    return filter_names
 
 
 def _apply_filters(names_list, incl_filters, skip_filters):

--- a/src/test/test_db_introspects.py
+++ b/src/test/test_db_introspects.py
@@ -145,5 +145,3 @@ class DBIntrospectsTest(unittest.TestCase):
         result = _apply_filters(names_list, incl_filters=None, skip_filters=skip_filters)
         self.assertSetEqual(set(expected), result)
 
-
-# Test filter without wildcards

--- a/src/test/test_db_introspects.py
+++ b/src/test/test_db_introspects.py
@@ -40,6 +40,18 @@ class DBIntrospectsTest(unittest.TestCase):
         result = _apply_filters(names_list, incl_filters=incl_filters, skip_filters=None)
         self.assertSetEqual(set(expected), result)
 
+    def test_apply_filters_incl_filters_no_wildcards(self):
+        names_list = [
+            'species1_core_105_1',
+            'species2_core_105_1',
+            'species3_core_104_2',
+            'species4_core_104_2',
+        ]
+        incl_filters = ['core_105']
+        expected = []
+        result = _apply_filters(names_list, incl_filters=incl_filters, skip_filters=None)
+        self.assertSetEqual(set(expected), result)
+
     def test_apply_filters_incl_filters_and_matches(self):
         names_list = [
             'species1_core_105_1',
@@ -67,6 +79,23 @@ class DBIntrospectsTest(unittest.TestCase):
         skip_filters = ['species2.*']
         expected = [
             'species1_core_105_1',
+            'species4_core_104_2',
+        ]
+        result = _apply_filters(names_list, incl_filters=incl_filters, skip_filters=skip_filters)
+        self.assertSetEqual(set(expected), result)
+
+    def test_apply_filters_incl_filters_and_matches_skip_filters_no_wildcards(self):
+        names_list = [
+            'species1_core_105_1',
+            'species2_core_105_1',
+            'species3_core_104_2',
+            'species4_core_104_2',
+        ]
+        incl_filters = ['.*core_105.*', 'species4_core_104_2']
+        skip_filters = ['species2']
+        expected = [
+            'species1_core_105_1',
+            'species2_core_105_1',
             'species4_core_104_2',
         ]
         result = _apply_filters(names_list, incl_filters=incl_filters, skip_filters=skip_filters)
@@ -115,3 +144,6 @@ class DBIntrospectsTest(unittest.TestCase):
         ]
         result = _apply_filters(names_list, incl_filters=None, skip_filters=skip_filters)
         self.assertSetEqual(set(expected), result)
+
+
+# Test filter without wildcards


### PR DESCRIPTION
Enable the use case of a filter matching all **and only** names precisely.
E.g. If the available names are `{'db1', 'db2', 'db'}`
     `get_database_set(..., incl_filters=['db']` returns `{'db'}`