### PR TITLE
Prevent hive.HiveInstance from using nested SQLAlchemy sessions

### DIFF
--- a/src/ensembl/production/core/models/hive.py
+++ b/src/ensembl/production/core/models/hive.py
@@ -18,7 +18,7 @@ import time
 from sqlalchemy import create_engine, Column, Integer, String, ForeignKey, func, and_
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship
+from sqlalchemy.orm import sessionmaker, relationship, joinedload
 
 from ensembl.production.core.perl_utils import dict_to_perl_string, perl_string_to_python
 
@@ -158,158 +158,149 @@ Session = sessionmaker()
 
 
 class HiveInstance:
-    analysis_dict = dict()
+    analysis_dict = {}
 
     def __init__(self, url, timeout=3600):
-        self.engine = create_engine(url, pool_recycle=timeout, echo=False)
+        self.engine = create_engine(url, pool_recycle=timeout)
         Session.configure(bind=self.engine)
 
     def get_job_by_id(self, id):
         """ Retrieve a job given the unique surrogate ID """
-        s = Session()
-        try:
-            job = s.query(Job).filter(Job.job_id == id).first()
-            if job is None:
-                raise ValueError("Job %s not found" % id)
-            job.result
-            return job
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_job_by_id(id, session)
+
+    def _get_job_by_id(self, id, session):
+        job = session.query(Job).options(joinedload(Job.result)).filter(Job.job_id == id).first()
+        if job is None:
+            raise ValueError("Job %s not found" % id)
+        return job
 
     def get_worker_id(self, id):
         """ Retrieve a worker_id for a given role_id """
-        s = Session()
-        try:
-            return s.query(Role).filter(Role.role_id == id).first()
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_worker_id(id, session)
+
+    def _get_worker_id(self, id, session):
+        return session.query(Role).filter(Role.role_id == id).first()
 
     def get_jobs_failure_msg(self, id):
         """Get failures for all the parent and child jobs"""
-        s = Session()
-        try:
-            failures = {}
-            parent_job = self.get_job_by_id(id)
-            if parent_job.status == 'FAILED':
-                failures[id] = self.get_job_failure_msg_by_id(id).msg
-            for child_job in s.query(Job).filter(Job.prev_job_id == id).all():
-                if child_job.status == 'FAILED':
-                    failures[child_job.job_id] = self.get_job_failure_msg_by_id(child_job.job_id).msg
-            return failures
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_jobs_failure_msg(id, session)
+
+    def _get_jobs_failure_msg(self, id, session):
+        failures = {}
+        parent_job = self.get_job_by_id(id)
+        if parent_job.status == 'FAILED':
+            failures[id] = self._get_job_failure_msg_by_id(id, session).msg
+        for child_job in session.query(Job).filter(Job.prev_job_id == id).all():
+            if child_job.status == 'FAILED':
+                failures[child_job.job_id] = self._get_job_failure_msg_by_id(child_job.job_id, session).msg
+        return failures
 
     def get_job_failure_msg_by_id(self, id, child=False):
         """ Retrieve a job failure message or job child if exist and if child flag turned on"""
-        s = Session()
-        job = self.get_job_by_id(id)
+        with Session() as session:
+            return self._get_job_failure_msg_by_id(id, session, child)
+
+    def _get_job_failure_msg_by_id(self, id, session, child=False):
+        job = self._get_job_by_id(id, session)
         if job is None:
             raise ValueError("Job %s not found" % id)
         if child:
-            child_job = self.get_job_child(job)
+            child_job = self._get_job_child(job, session)
             if child_job is not None:
-                try:
-                    return s.query(LogMessage).filter(LogMessage.job_id == child_job.job_id).order_by(
-                        LogMessage.log_message_id.desc()).first()
-                finally:
-                    s.close()
-            else:
-                try:
-                    return s.query(LogMessage).filter(LogMessage.job_id == id).order_by(
-                        LogMessage.log_message_id.desc()).first()
-                finally:
-                    s.close()
-        else:
-            try:
-                return s.query(LogMessage).filter(LogMessage.job_id == id).order_by(
+                return session.query(LogMessage).filter(LogMessage.job_id == child_job.job_id).order_by(
                     LogMessage.log_message_id.desc()).first()
-            finally:
-                s.close()
+            return session.query(LogMessage).filter(LogMessage.job_id == id).order_by(
+                LogMessage.log_message_id.desc()).first()
+        return session.query(LogMessage).filter(LogMessage.job_id == id).order_by(
+            LogMessage.log_message_id.desc()).first()
 
     def get_worker_process_id(self, id):
         """ Find a workers process_id """
-        s = Session()
-        try:
-            return s.query(Worker).filter(Worker.worker_id == id).first()
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_worker_process_id(id, session)
+
+    def _get_worker_process_id(self, id, session):
+        return session.query(Worker).filter(Worker.worker_id == id).first()
 
     def get_analysis_by_name(self, name):
         """ Find an analysis """
-        s = Session()
-        try:
-            return s.query(Analysis).filter(Analysis.logic_name == name).first()
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_analysis_by_name(name, session)
+
+    def _get_analysis_by_name(self, name, session):
+        return session.query(Analysis).filter(Analysis.logic_name == name).first()
 
     def create_job(self, analysis_name, input_data):
         """
         Create a job for the supplied analysis and input hash
         The input_data dict is converted to a Perl string before storing
         """
+        with Session() as session:
+            return self._create_job(analysis_name, input_data, session)
+
+    def _create_job(self, analysis_name, input_data, session):
         input_data['timestamp'] = time.ctime()
-        analysis = self.get_analysis_by_name(analysis_name)
+        analysis = self._get_analysis_by_name(analysis_name, session)
         if analysis is None:
             raise ValueError("Analysis %s not found" % analysis_name)
-        s = Session()
-        try:
-            job = Job(input_id=dict_to_perl_string(input_data), status='READY', analysis_id=analysis.analysis_id);
-            s.add(job)
-            s.commit()
-            # force load of object
-            # FIXME any param in connexion should force the loading.
-            job.analysis
-            job.result
-            return job
-        except SQLAlchemyError:
-            s.rollback()
-            raise
-        finally:
-            s.close()
+        job = Job(input_id=dict_to_perl_string(input_data), status='READY', analysis_id=analysis.analysis_id)
+        session.add(job)
+        session.commit()
+        # force load of object
+        # FIXME any param in connexion should force the loading.
+        job.analysis
+        job.result
+        return job
 
     def get_analysis_data_input(self, analysis_data_id):
         """ Get the job input stored in the analysis_data table. Get input from child job if exist"""
-        s = Session()
-        try:
-            input_job = s.query(AnalysisData).filter(AnalysisData.analysis_data_id == analysis_data_id).first()
-            return input_job
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_analysis_data_input(analysis_data_id, session)
+
+    def _get_analysis_data_input(self, analysis_data_id, session):
+        return session.query(AnalysisData).filter(AnalysisData.analysis_data_id == analysis_data_id).first()
 
     def get_semaphore_data(self, semaphore_job_id):
         """ Get the job semaphore count if exist"""
-        s = Session()
-        try:
-            semaphore_data = s.query(Semaphore).filter(Semaphore.dependent_job_id == semaphore_job_id).first()
-            return semaphore_data
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_semaphore_data(semaphore_job_id, session)
+
+    def _get_semaphore_data(self, semaphore_job_id, session):
+        return session.query(Semaphore).filter(Semaphore.dependent_job_id == semaphore_job_id).first()
 
     def get_result_for_job_id(self, id, child=False, progress=True, analysis_id=None):
         """ Get result for a given job id. If child flag is turned on and job child exist, get result for child job"""
+        with Session() as session:
+            return self._get_result_for_job_id(id, session, child, progress, analysis_id)
 
-        job = self.get_job_by_id(id)
+    def _get_result_for_job_id(self, id, session, child=False, progress=True, analysis_id=None):
+        job = self._get_job_by_id(id, session)
         if job is None:
-            raise ValueError("Job %s not found" % id)
+            raise ValueError(f"Job {id} not found")
         if child:
-            child_job = self.get_job_child(job)
+            child_job = self._get_job_child(job, session)
             if child_job is not None:
-                return self.get_result_for_job(child_job, progress=progress)
-            else:
-                return self.get_result_for_job(job, progress=progress)
-        else:
-            return self.get_result_for_job(job, progress=progress, analysis_id=analysis_id)
+                return self._get_result_for_job(child_job, session, progress)
+            return self._get_result_for_job(job, session, progress)
+        return self._get_result_for_job(job, session, progress, analysis_id)
 
     def get_result_for_job(self, job, progress=False, analysis_id=None):
         """
         Determine if the job has completed. If the job has semaphored children, they are also checked
         Also return progress of jobs, completed and total if flag is on
         """
+        with Session() as session:
+            return self._get_result_for_job(job, session, progress, analysis_id)
+
+    def _get_result_for_job(self, job, session, progress=False, analysis_id=None):
         result = {"id": job.job_id}
         try:
             if re.search(r"^(_extended_data_id){1}(\s){1}(\d+){1}", job.input_id):
                 extended_data = job.input_id.split(" ")
-                job_input = self.get_analysis_data_input(extended_data[1])
+                job_input = self._get_analysis_data_input(extended_data[1], session)
                 result['input'] = perl_string_to_python(job_input.data)
 
             else:
@@ -319,53 +310,50 @@ class HiveInstance:
                 result['when_completed'] = job.when_completed
                 result['output'] = job.result.output_dict()
             else:
-                result['status'] = self.get_job_tree_status(job)
+                result['status'] = self._get_job_tree_status(job, session)
             if progress:
-                result['progress'] = self.get_all_jobs_progress(job.job_id, analysis_id=analysis_id)
+                result['progress'] = self._get_all_jobs_progress(job.job_id, session, analysis_id=analysis_id)
         except ValueError as e:
-            raise ValueError('Cannot retrieve results for job: {}'.format(job.job_id)) from e
+            raise ValueError(f'Cannot retrieve results for job: {job.job_id}') from e
         except SQLAlchemyError as e:
-            raise ValueError('DB error for job: {}'.format(job.job_id)) from e
+            raise ValueError(f'DB error for job: {job.job_id}') from e
         return result
 
     def get_all_jobs_progress(self, job_id, analysis_id=None):
         """
         Get all jobs from Job table based on given job id and analysis id
         """
-        s = Session()
-        try:
-            results = {'total': 0, 'inprogress': 0, 'completed': 0, 'failed': 0}
-            job_pattern = f"{job_id},%"
+        with Session() as session:
+            return self._get_all_jobs_progress(job_id, session, analysis_id)
 
-            if analysis_id:
-                jobs = s.query(Job).filter(
-                    and_(Job.param_id_stack.ilike(job_pattern), Job.analysis_id == analysis_id)).all()
+    def _get_all_jobs_progress(self, job_id, session, analysis_id=None):
+        results = {'total': 0, 'inprogress': 0, 'completed': 0, 'failed': 0 }
+        job_pattern = f"{job_id},%"
+
+        if analysis_id:
+            jobs = session.query(Job).filter(and_(Job.param_id_stack.ilike(job_pattern), Job.analysis_id == analysis_id ) ).all()
+        else:
+            jobs = session.query(Job).filter(Job.param_id_stack.ilike(job_pattern) ).all()
+
+        for job in jobs:
+            results['total'] += 1
+            if job.status == 'DONE':
+                results['completed'] += 1
+            elif job.status == 'FAILED':
+                results['failed'] += 1
             else:
-                jobs = s.query(Job).filter(Job.param_id_stack.ilike(job_pattern)).all()
-
-            for job in jobs:
-                results['total'] += 1
-                if job.status == 'DONE':
-                    results['completed'] += 1
-                elif job.status == 'FAILED':
-                    results['failed'] += 1
-                else:
-                    results['inprogress'] += 1
-            return results
-        except Exception as e:
-            return results
-        finally:
-            s.close()
+                results['inprogress'] += 1
+        return results
 
     def get_last_job_progress(self, job):
         """ Return last job progress line if exists, else None """
-        s = Session()
-        try:
-            last_job_progress_msg = s.query(JobProgress).filter(JobProgress.job_id == job.job_id).order_by(
-                JobProgress.job_progress_id.desc()).first()
-            return last_job_progress_msg
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_last_job_progress(job, session)
+
+    def _get_last_job_progress(self, job, session):
+        last_job_progress_msg = session.query(JobProgress).filter(JobProgress.job_id == job.job_id).order_by(
+            JobProgress.job_progress_id.desc()).first()
+        return last_job_progress_msg
 
     def get_jobs_progress(self, job):
         """
@@ -374,81 +362,73 @@ class HiveInstance:
         Return number of completed jobs and total of jobs
         If there is data in the job_progress table, return progress message
         """
-        s = Session()
-        try:
-            last_job_progress_msg = s.query(JobProgress).filter(JobProgress.job_id == job.job_id).order_by(
-                JobProgress.job_progress_id.desc()).first()
-            if last_job_progress_msg is not None:
-                total = 10
-                complete = s.query(JobProgress).filter(JobProgress.job_id == job.job_id).count()
-                return {"complete": complete, "total": total, "message": last_job_progress_msg.message}
-            else:
-                total = 1
-                complete = 0
-                parent_job = self.get_job_by_id(job.job_id)
-                if parent_job.status == 'DONE':
-                    complete += 1
-                for child_job in s.query(Job).filter(Job.prev_job_id == job.job_id).all():
-                    total += 1
-                    if child_job.status == 'DONE':
-                        complete += 1
-                return {"complete": complete, "total": total}
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_jobs_progress(job, session)
+
+    def _get_jobs_progress(self, job, session):
+        last_job_progress_msg = session.query(JobProgress).filter(JobProgress.job_id == job.job_id).order_by(
+            JobProgress.job_progress_id.desc()).first()
+        if last_job_progress_msg is not None:
+            total = 10
+            complete = session.query(JobProgress).filter(JobProgress.job_id == job.job_id).count()
+            return {"complete": complete, "total": total, "message": last_job_progress_msg.message}
+        total = 1
+        complete = 0
+        parent_job = self._get_job_by_id(job.job_id, session)
+        if parent_job.status == 'DONE':
+            complete += 1
+        for child_job in session.query(Job).filter(Job.prev_job_id == job.job_id).all():
+            total += 1
+            if child_job.status == 'DONE':
+                complete += 1
+        return {"complete": complete, "total": total}
 
     def get_job_tree_status(self, job):
         """ Recursively check all children of a job """
+        with Session() as session:
+            return self._get_job_tree_status(job, session)
+
+    def _get_job_tree_status(self, job, session):
         # check for semaphores
         semaphore_data = None
         logger.debug("get_job_tree_status :: job: %s", job)
-        try:
-            s = Session()
-            semaphored_job = s.query(Job).filter(Job.prev_job_id == job.job_id and job.status == 'SEMAPHORED').first()
-            logger.debug("get_job_tree_status :: semaphored_job: %s", semaphored_job)
-            if semaphored_job is not None:
-                semaphore_data = self.get_semaphore_data(semaphored_job.job_id)
-            logger.debug("get_job_tree_status :: semaphore_data: %s", semaphore_data)
-        finally:
-            s.close()
+        semaphored_job = session.query(Job).filter(Job.prev_job_id == job.job_id and job.status == 'SEMAPHORED').first()
+        logger.debug("get_job_tree_status :: semaphored_job: %s", semaphored_job)
+        if semaphored_job is not None:
+            semaphore_data = self._get_semaphore_data(semaphored_job.job_id, session)
+        logger.debug("get_job_tree_status :: semaphore_data: %s", semaphore_data)
         if semaphore_data is not None and semaphore_data.local_jobs_counter > 0:
-            return self.check_semaphores_for_job(semaphore_data)
+            return self._check_semaphores_for_job(semaphore_data, session)
+        if job.status == 'FAILED':
+            return 'failed'
+        if job.status == 'READY':
+            return 'submitted'
+        if job.status == 'RUN':
+            return 'running'
+        if job.status == 'DONE':
+            for child_job in session.query(Job).filter(Job.prev_job_id == job.job_id).all():
+                child_status = self._get_job_tree_status(child_job, session)
+                if child_status != 'complete':
+                    return child_status
+            return 'complete'
         else:
-            if job.status == 'FAILED':
-                return 'failed'
-            elif job.status == 'READY':
-                return 'submitted'
-            elif job.status == 'RUN':
-                return 'running'
-            elif job.status == 'DONE':
-                s = Session()
-                try:
-                    for child_job in s.query(Job).filter(Job.prev_job_id == job.job_id).all():
-                        child_status = self.get_job_tree_status(child_job)
-                        if child_status != 'complete':
-                            return child_status
-                    return 'complete'
-                finally:
-                    s.close()
-            else:
-                return 'incomplete'
+            return 'incomplete'
 
     def get_job_child(self, job):
         """ Get child job for a given parent job """
-        s = Session()
-        try:
-            child_job = s.query(Job).filter(Job.prev_job_id == job.job_id).first()
-            return child_job
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_job_child(job, session)
+
+    def _get_job_child(self, job, session):
+        return session.query(Job).filter(Job.prev_job_id == job.job_id).first()
 
     def get_job_parent(self, job):
         """ Get parent job for a given children job """
-        s = Session()
-        try:
-            parent_job = s.query(Job).filter(Job.job_id == job.prev_job_id).first()
-            return parent_job
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_job_parent(job, session)
+
+    def _get_job_parent(self, job, session):
+        return session.query(Job).filter(Job.job_id == job.prev_job_id).first()
 
     def get_semaphored_jobs(self, job, status=None):
         """
@@ -457,89 +437,72 @@ class HiveInstance:
         'failed' indicates that at least one child has failed
         'incomplete' indicates that at least one child is running or ready
         """
-        s = Session()
-        try:
-            semaphored_job = s.query(Job).filter(Job.prev_job_id == job.job_id, job.status == 'SEMAPHORED').first()
-            semaphore_data = self.get_semaphore_data(semaphored_job.job_id)
-            if status is None:
-                return s.query(Job).filter(semaphore_data.semaphore_id == Job.controlled_semaphore_id).all()
-            else:
-                return s.query(Job).filter(semaphore_data.semaphore_id == Job.controlled_semaphore_id,
-                                           Job.status == status).all()
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_semaphored_jobs(job, session, status)
+
+    def _get_semaphored_jobs(self, job, session, status=None):
+        semaphored_job = session.query(Job).filter(Job.prev_job_id == job.job_id, job.status == 'SEMAPHORED').first()
+        semaphore_data = self._get_semaphore_data(semaphored_job.job_id, session)
+        if status is None:
+            return session.query(Job).filter(semaphore_data.semaphore_id == Job.controlled_semaphore_id).all()
+        return session.query(Job).filter(semaphore_data.semaphore_id == Job.controlled_semaphore_id, Job.status == status).all()
 
     def check_semaphores_for_job(self, semaphore_data):
         """ Find all jobs that are semaphored children of the nominated job, and check whether they have completed """
-        s = Session()
-        try:
-            status = 'complete'
-            jobs = dict(s.query(Job.status, func.count(Job.status)).filter(
-                semaphore_data.semaphore_id == Job.controlled_semaphore_id).group_by(Job.status).all())
-            logger.debug("check_semaphores_for_job :: jobs: %s", jobs)
-            if jobs.get('FAILED', 0) > 0:
-                status = 'failed'
-            elif jobs.get('READY', 0) > 0 or jobs.get('RUN', 0) > 0 or jobs.get('SEMAPHORED', 0) > 0:
-                status = 'incomplete'
-            return status
-        finally:
-            s.close()
+        with Session() as session:
+            return self._check_semaphores_for_job(semaphore_data, session)
+
+    def _check_semaphores_for_job(self, semaphore_data, session):
+        status = 'complete'
+        jobs = dict(session.query(Job.status, func.count(Job.status)).filter(
+            semaphore_data.semaphore_id == Job.controlled_semaphore_id).group_by(Job.status).all())
+        logger.debug("check_semaphores_for_job :: jobs: %s", jobs)
+        if jobs.get('FAILED', 0) > 0:
+            status = 'failed'
+        elif jobs.get('READY', 0) > 0 or jobs.get('RUN', 0) > 0 or jobs.get('SEMAPHORED', 0) > 0:
+            status = 'incomplete'
+        return status
 
     def get_all_results(self, analysis_name, child=False):
         """Find all jobs from the specified analysis"""
-        s = Session()
-        try:
-            jobs = s.query(Job).join(Analysis).filter(Analysis.logic_name == analysis_name).all()
-            if child:
-                return list(map(lambda job: self.get_result_for_job(self.get_job_child(job)) if (
-                        self.get_job_child(job) is not None) else self.get_result_for_job(job), jobs))
-            else:
-                return list(map(lambda job: self.get_result_for_job(job), jobs))
-        finally:
-            s.close()
+        with Session() as session:
+            return self._get_all_results(analysis_name, session, child)
+
+    def _get_all_results(self, analysis_name, session, child=False):
+        jobs = session.query(Job).join(Analysis).filter(Analysis.logic_name == analysis_name).all()
+        if child:
+            return list(
+                map(lambda job: self._get_result_for_job(self._get_job_child(job, session), session) if (
+                    self._get_job_child(job, session) is not None) else self._get_result_for_job(job, session),
+                    jobs)
+            )
+        return list(map(lambda job: self._get_result_for_job(job, session), jobs))
 
     def delete_job(self, job, child=False):
         """Delete a job from the hive database
            If child flag turn on, try to delete child job if exist
            Also get parent job if exist and delete it """
-        parent_job = self.get_job_parent(job)
+        with Session() as session:
+            return self._delete_job(job, session, child)
+
+    def _delete_job(self, job, session, child=False):
+        parent_job = self._get_job_parent(job, session)
         if child:
-            child_job = self.get_job_child(job)
+            child_job = self._get_job_child(job, session)
             if child_job is not None:
-                s = Session()
-                try:
-                    logger.debug("Deleting children job %s " + child_job.job_id)
-                    if child_job.result is not None:
-                        s.delete(child_job.result)
-                    s.delete(child_job)
-                    s.commit()
-                except SQLAlchemyError:
-                    s.rollback()
-                    raise
-                finally:
-                    s.close()
+                logger.debug("Deleting children job %s", child_job.job_id)
+                if child_job.result is not None:
+                    session.delete(child_job.result)
+                session.delete(child_job)
+                session.commit()
         if parent_job is not None:
-            s = Session()
-            try:
-                logger.debug("Deleting parent job %s " + parent_job.job_id)
-                if parent_job.result is not None:
-                    s.delete(parent_job.result)
-                s.delete(parent_job)
-                s.commit()
-            except SQLAlchemyError:
-                s.rollback()
-                raise
-            finally:
-                s.close()
-        try:
-            s = Session()
-            logger.debug("Deleting job %s " + job.job_id)
-            if job.result is not None:
-                s.delete(job.result)
-            s.delete(job)
-            s.commit()
-        except SQLAlchemyError:
-            s.rollback()
-            raise
-        finally:
-            s.close()
+            logger.debug("Deleting parent job %s", parent_job.job_id)
+            if parent_job.result is not None:
+                session.delete(parent_job.result)
+            session.delete(parent_job)
+            session.commit()
+        logger.debug("Deleting job %s", job.job_id)
+        if job.result is not None:
+            session.delete(job.result)
+        session.delete(job)
+        session.commit()

--- a/src/ensembl/production/core/models/hive.py
+++ b/src/ensembl/production/core/models/hive.py
@@ -411,8 +411,7 @@ class HiveInstance:
                 if child_status != 'complete':
                     return child_status
             return 'complete'
-        else:
-            return 'incomplete'
+        return 'incomplete'
 
     def get_job_child(self, job):
         """ Get child job for a given parent job """

--- a/src/ensembl/production/core/models/hive.py
+++ b/src/ensembl/production/core/models/hive.py
@@ -478,6 +478,15 @@ class HiveInstance:
             )
         return list(map(lambda job: self._get_result_for_job(job, session), jobs))
 
+    def delete_job_by_id(self, job_id, child=False):
+        """Delete a job from the hive database given its id"""
+        with Session() as session:
+            return self._delete_job_by_id(job_id, session, child)
+
+    def _delete_job_by_id(self, job_id, session, child=False):
+        job = self._get_job_by_id(job_id, session)
+        return self._delete_job(job, session, child)
+
     def delete_job(self, job, child=False):
         """Delete a job from the hive database
            If child flag turn on, try to delete child job if exist

--- a/src/test/test_hive.py
+++ b/src/test/test_hive.py
@@ -47,6 +47,11 @@ class HiveTest(unittest.TestCase):
         logger.info("Connecting to hive test sqlite database %s", here/DB_FILENAME)
         self.hive = HiveInstance(f"sqlite:///{here/DB_FILENAME}")
 
+    def tearDown(self):
+        """Remove test database file"""
+        logger.info("Removing test sqlite database")
+        os.remove(here/DB_FILENAME)
+
     def test_create_job(self):
         """Basic test case for creating a new job"""
         job1 = self.hive.create_job('TestRunnable', {'x': 'y', 'a': 'b'})
@@ -121,10 +126,12 @@ class HiveTest(unittest.TestCase):
         jobs = self.hive.get_all_results('TestRunnable')
         self.assertEqual(1, len(jobs), "Checking we got just one job")
 
-    def tearDown(self):
-        """Remove test database file"""
-        logger.info("Removing test sqlite database")
-        os.remove(here/DB_FILENAME)
+    def test_delete_job(self):
+        job = self.hive.create_job('TestRunnable', {'x': 'y', 'a': 'b'})
+        job_id = self.hive.get_job_by_id(job.job_id).job_id
+        self.assertEqual(job.job_id, job_id)
+        self.hive.delete_job(job)
+        self.assertRaises(ValueError, self.hive.get_job_by_id, job.job_id)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Prevent `hive.HiveInstance` from using nested SQLAlchemy sessions
    - Reuse sessions by separating the business logic into private methods and creating sessions in public methods. Private methods will call other private methods (instead of public) and share the same session.
    - Improve readability and simplify the code by using `with` blocks instead of `try` for sessions
- Add `delete_job_by_id()` to `hive.HiveInstance`

