### PR TITLE
update sqlalchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ kombu~=5.0.2
 PyYAML~=6.0
 requests>=2.25,<3
 six~=1.15.0
-SQLAlchemy~=1.4.6
-SQLAlchemy-Utils~=0.37.0
+SQLAlchemy~=1.4.34
+SQLAlchemy-Utils~=0.38.2


### PR DESCRIPTION
Current Version of sqlalchemy is not compatibility for Mysql server  version  5.7, 
updated sqlalchemy and its utils to latest version